### PR TITLE
fix: synchronize logout across tabs

### DIFF
--- a/src/boot/axios.js
+++ b/src/boot/axios.js
@@ -4,7 +4,7 @@ import axios from 'axios'
 const api = axios.create({ baseURL: 'https://0ab9dc3f804f.ngrok-free.app' })
 
 api.interceptors.request.use(config => {
-  const token = sessionStorage.getItem('token')
+  const token = localStorage.getItem('token')
 
   if (token && !config.url.includes('/login')) {
     config.headers.Authorization = `Bearer ${token}`

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,6 +20,7 @@ export default defineRouter(function (/* { store, ssrContext } */) {
   })
 
   const authStore = useAuthStore()
+  authStore.init()
 
   Router.beforeEach(async (to, from, next) => {
     if (to.meta.requiresAuth) {


### PR DESCRIPTION
## Summary
- persist auth token in localStorage instead of per-tab sessionStorage
- react to token removal across tabs and redirect to login
- initialize auth store listener at router setup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ff222d7508331ad78d408d7c11794