### PR TITLE
chore: trigger deploy workflow on main commits and merged PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,13 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+    types: [closed]
 
 jobs:
   build-and-deploy:
-    if: github.actor != 'github-actions[bot]'
+    if: github.actor != 'github-actions[bot]' && (github.event_name == 'push' || github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
 
     steps:
@@ -22,7 +25,7 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: npm run build
+        run: quasar build
 
       - name: Update docs
         run: |
@@ -32,4 +35,4 @@ jobs:
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git add docs
           git commit -m "chore: update docs" || echo "No changes to commit"
-          git push
+          git push origin HEAD:main


### PR DESCRIPTION
## Summary
- ensure deploy workflow runs on pushes to `main` and when pull requests are merged
- prevent deploy job from running for non-merged PR events or bot commits
- build docs with `quasar build`
- push committed docs updates back to `main`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a15584e9e483318f0fc91e53d1cd87