### PR TITLE
fix deploy workflow to use npm build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: quasar build
+        run: npm run build
 
       - name: Update docs
         run: |


### PR DESCRIPTION
## Summary
- call `npm run build` during deploy instead of relying on a global `quasar` command

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1da6ef44c8331b2c607259cc3877c