### PR TITLE
fix: grant workflow push access

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
     branches: [master]
     types: [closed]
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     if: github.actor != 'github-actions[bot]' && (github.event_name == 'push' || github.event.pull_request.merged == true)


### PR DESCRIPTION
## Summary
- ensure deploy workflow can push docs by granting contents write

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1dbf354248331a778507cc7b25d9f