### PR TITLE
[FICE-1] Isolate staff portal auth storage from the admin app.

### DIFF
--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -2763,22 +2763,24 @@ export const apiPaths = {
   )}/favorite`,
 }
 
+export const authStorageNamespace = 'fice-medical.auth'
+
 export const authStorageKeys = {
-  token: 'token',
-  expireAt: 'expireAt',
-  expireAtLegacy: 'expiresAt',
-  refresh: 'refreshToken',
-  refreshLegacy: 'refresh_token',
-  modules: 'modules',
-  permissions: 'permissions',
-  subtenants: 'subtenants',
-  activeSubtenantId: 'activeSubtenantId',
-  tenantId: 'tenantId',
-  configData: 'configData',
-  userInfo: 'userInfo',
-  mustChangePassword: 'mustChangePassword',
-  passwordChangeMode: 'passwordChangeMode',
-  mustEnrollMfa: 'mustEnrollMfa',
+  token: `${authStorageNamespace}.token`,
+  expireAt: `${authStorageNamespace}.expireAt`,
+  expireAtLegacy: `${authStorageNamespace}.expiresAt`,
+  refresh: `${authStorageNamespace}.refreshToken`,
+  refreshLegacy: `${authStorageNamespace}.refresh_token`,
+  modules: `${authStorageNamespace}.modules`,
+  permissions: `${authStorageNamespace}.permissions`,
+  subtenants: `${authStorageNamespace}.subtenants`,
+  activeSubtenantId: `${authStorageNamespace}.activeSubtenantId`,
+  tenantId: `${authStorageNamespace}.tenantId`,
+  configData: `${authStorageNamespace}.configData`,
+  userInfo: `${authStorageNamespace}.userInfo`,
+  mustChangePassword: `${authStorageNamespace}.mustChangePassword`,
+  passwordChangeMode: `${authStorageNamespace}.passwordChangeMode`,
+  mustEnrollMfa: `${authStorageNamespace}.mustEnrollMfa`,
 }
 
 export const passwordChangeModes = {

--- a/src/stores/auth-store.js
+++ b/src/stores/auth-store.js
@@ -1,7 +1,12 @@
 import { defineStore } from 'pinia'
 import { apiInstance } from 'boot/axios'
-import { apiPaths, permissionNames, passwordChangeModes, typeNames }
-  from 'components/constants.js'
+import {
+  apiPaths,
+  authStorageKeys,
+  permissionNames,
+  passwordChangeModes,
+  typeNames,
+} from 'components/constants.js'
 import {
   hasAnyPermission,
   hasAssignedPermissions,
@@ -534,7 +539,7 @@ export const useAuthStore = defineStore('auth', {
       this._initialized = true
       if (typeof window !== typeNames.undefined) {
         window.addEventListener('storage', event => {
-          if (event.key === 'token' && event.newValue === null) {
+          if (event.key === authStorageKeys.token && event.newValue === null) {
             this.token = null
             this.expireAt = null
             this.refreshToken = null

--- a/src/utils/auth-storage-crypto.js
+++ b/src/utils/auth-storage-crypto.js
@@ -1,6 +1,6 @@
 export const AUTH_STORAGE_PACKED_PREFIX = 'enc.v1:'
 const PACKED_PREFIX = AUTH_STORAGE_PACKED_PREFIX
-export const AUTH_WRAP_STORAGE_KEY = 'fice.auth.wrap.v1'
+export const AUTH_WRAP_STORAGE_KEY = 'fice-medical.auth.wrap.v1'
 
 function bytesToBase64(bytes) {
   const chunk = 0x8000


### PR DESCRIPTION
## Summary
- Namespace staff portal auth keys as `fice-medical.auth.*` so they no longer collide with the admin portal on the same origin.
- Update the logout storage listener to watch the namespaced token key.

## Test plan
- [x] Log in to the staff portal, then open the admin portal in another tab: admin should stay logged out (or keep its own session).
- [x] Log in to the admin portal, then open the staff portal in another tab: staff should not reuse the admin token.
- [x] Confirm this PR check `PR & Branch Standards` passes.


Made with [Cursor](https://cursor.com)